### PR TITLE
Fixed table.set('selection'), which did not set the cached value.

### DIFF
--- a/addon/components/ember-table.js
+++ b/addon/components/ember-table.js
@@ -87,6 +87,9 @@ StyleBindingsMixin, ResizeHandlerMixin, {
         this.get('persistedSelection').clear();
         this.get('rangeSelection').clear();
         switch (selectionMode) {
+          case 'none':
+            val = null;
+            break;
           case 'single':
             this.get('persistedSelection').addObject(val);
             break;
@@ -94,7 +97,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
             this.get('persistedSelection').addObjects(val);
         }
       }
-      return this.get('selection');
+      return val;
     },
     get: function() {
       var selectionMode = this.get('selectionMode');
@@ -559,7 +562,7 @@ StyleBindingsMixin, ResizeHandlerMixin, {
   // TODO(azirbel): Document
   actions: {
     addColumn: Ember.K,
-    
+
     sortByColumn: function(column) {
       this.sendAction('sortByColumn', column);
     },


### PR DESCRIPTION
Fixes table.set('selection', whatever). The passed `val` should be returned. As written, when `this.get('selection')` is called, it simply returns the already-cached value. The returned value is then written to the cache, resulting in a no-op. The selection is not set.